### PR TITLE
Fix error that was preventing schema install from succeeding

### DIFF
--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -1,5 +1,5 @@
 <?php
-class SQLBoss2Schema extends CakeSchema
+class SQLBossSchema extends CakeSchema
 {
     public function before($event = array())
     {

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Configure the rest of the app in ```Config/core.php```
 ### Create the database schema using CakePHP migrations
 
 ```
-Vendor/cakephp/cakephp/lib/Cake/Console/cake schema create
+Vendor/cakephp/cakephp/lib/Cake/Console/cake schema create sqlboss
 Vendor/cakephp/cakephp/lib/Cake/Console/cake schema create sessions
 ```
 


### PR DESCRIPTION
```
---------------------------------------------------------------
App : sqlboss
Path: /Users/lightster/server.local/html/sqlboss/
---------------------------------------------------------------
Cake Schema Shell
---------------------------------------------------------------
The chosen schema could not be loaded. Attempted to load:
File: /Users/lightster/server.local/html/sqlboss/Config/Schema/schema.php
Name: Sqlboss
```
