### PR TITLE
Add JSON type to DBAL

### DIFF
--- a/Lib/SQLBoss/DBAL/Types/JsonType.php
+++ b/Lib/SQLBoss/DBAL/Types/JsonType.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SQLBoss\DBAL\Types;
+
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+
+class JsonType extends Type
+{
+    const JSONTYPE = 'jsontype';
+
+    public function getSqlDeclaration(array $fieldDeclaration, AbstractPlatform $platform)
+    {
+        return 'JSON';
+    }
+
+    public function convertToPHPValue($value, AbstractPlatform $platform)
+    {
+        return null;
+    }
+
+    public function convertToDatabaseValue($value, AbstractPlatform $platform)
+    {
+        return null;
+    }
+
+    public function getName()
+    {
+        return self::JSONTYPE;
+    }
+}

--- a/Lib/SQLBoss/TableDefinition.php
+++ b/Lib/SQLBoss/TableDefinition.php
@@ -20,6 +20,8 @@ class TableDefinition
         $this->platform = $this->remote_connection->getDatabasePlatform();
         \Doctrine\DBAL\Types\Type::addType('arrayintegertype', 'SQLBoss\DBAL\Types\ArrayIntegerType');
         $this->platform->registerDoctrineTypeMapping('_int4', 'arrayintegertype');
+        \Doctrine\DBAL\Types\Type::addType('jsontype', 'SQLBoss\DBAL\Types\JsonType');
+        $this->platform->registerDoctrineTypeMapping('json', 'jsontype');
 
         $this->sm = $this->remote_connection->getSchemaManager();
         $this->table = $this->sm->listTableDetails($table_name);


### PR DESCRIPTION
The `SELECT *` page was failing to load for tables that have a PostgreSQL column type of `json`. Adding a custom JSON type handler class to the DBAL solves this error.
