### PR TITLE
Allow limited user to edit their own password

### DIFF
--- a/Controller/UsersController.php
+++ b/Controller/UsersController.php
@@ -62,7 +62,7 @@ class UsersController extends AppController
         if ($this->request->is('post') || $this->request->is('put')) {
             if ($this->User->save($this->request->data)) {
                 $this->Session->setFlash(__('The user has been saved'));
-                $this->redirect(array('action' => 'index'));
+                $this->redirect(array('action' => 'edit', $id));
             } else {
                 $this->Session->setFlash(__('The user could not be saved. Please, try again.'));
             }


### PR DESCRIPTION
@zacharyrankin, when a user with a "Limited" access role submits the form to save their own password, they get a message that says "Not Authorized". This PR fixes the issue by redirecting back to the edit profile page instead of the restricted list users page.