### PR TITLE
Add index to improve history page performance

### DIFF
--- a/Config/Schema/schema.php
+++ b/Config/Schema/schema.php
@@ -36,7 +36,10 @@ class SQLBossSchema extends CakeSchema
         'created'    => array('type' => 'datetime', 'null' => true),
         'modified'   => array('type' => 'datetime', 'null' => true),
         'indexes'    => array(
-            'PRIMARY' => array('unique' => true, 'column' => 'id')
+            'PRIMARY' => array('unique' => true, 'column' => 'id'),
+            'queries_query_hash_idx' => array('column' => 'query_hash'),
+            'queries_user_id_idx' => array('column' => 'user_id'),
+            'queries_user_id_modified_idx' => array('column' => ['user_id', 'modified']),
         ),
         'tableParameters' => array()
     );


### PR DESCRIPTION
- Add index on queries.(user_id, modified) to improve
  "query history" query performance, which filters on user_id
  and sorts on modified time
- Add indexs on queries.user_id and queries.query_hash to
  match production

In order to get these updates, run:
```
./Vendor/cakephp/cakephp/lib/Cake/Console/cake schema update
```